### PR TITLE
Update archive.sh delete --restrict-filenames

### DIFF
--- a/archive.sh
+++ b/archive.sh
@@ -53,7 +53,6 @@ while true; do
 		--all-subs \
 		--embed-subs \
 		--embed-thumbnail \
-		--restrict-filenames \
 		--merge-output-format "mkv" \
 		--output "${OUTPUT_FORMAT}" \
 		--cookies "${COOKIES_FILE}" \


### PR DESCRIPTION
Applying the --restrict-filenames option, the problem that the video is not downloaded due to duplicate video titles fixed.

Confirmed that it works after removing the --restrict-filenames option.